### PR TITLE
Fixed filter bug with back button

### DIFF
--- a/client/components/Category.js
+++ b/client/components/Category.js
@@ -14,6 +14,11 @@ class Category extends Component {
     }
     this.handleChange = this.handleChange.bind(this)
   }
+
+  async componentDidMount() {
+    await this.setState({ category: this.props.filters.category })
+  }
+
   /* Using event.persist() makes this code work, but why doesn't it work without it? */
   async handleChange(event) {
     event.persist()
@@ -48,7 +53,6 @@ class Category extends Component {
           <input
             className="form-check-input"
             type="checkbox"
-            value=""
             id="defaultCheck2"
             name="Dark Chocolate"
             checked={this.state.category['Dark Chocolate']}
@@ -60,7 +64,6 @@ class Category extends Component {
           <input
             className="form-check-input"
             type="checkbox"
-            value=""
             id="defaultCheck3"
             name="White Chocolate"
             checked={this.state.category['White Chocolate']}

--- a/client/components/Price.js
+++ b/client/components/Price.js
@@ -9,6 +9,10 @@ class Price extends Component {
     this.handleChange = this.handleChange.bind(this)
   }
 
+  componentDidMount() {
+    this.setState({ price: this.props.filters.price })
+  }
+
   async handleChange(event) {
     event.persist()
     await this.setState({ price: event.target.valueAsNumber })

--- a/client/components/Search.js
+++ b/client/components/Search.js
@@ -5,9 +5,14 @@ import { addFilter, removeFilter } from '../store/filters'
 class Search extends Component {
   constructor() {
     super()
-    this.state = { searchString: '' }
+    this.state = { searchString: 'Enter product name' }
     this.handleChange = this.handleChange.bind(this)
   }
+
+  async componentDidMount() {
+    await this.setState({ searchString: this.props.filters.searchString })
+  }
+
   async handleChange(event) {
     event.persist()
     await this.setState({
@@ -28,6 +33,7 @@ class Search extends Component {
           type="text"
           name="searchString"
           placeholder="Enter product name"
+          value={this.state.searchString}
           onChange={this.handleChange}
         />
       </form>


### PR DESCRIPTION
Components weren't rendering applied filters when the AllProductsListing component was reached by hitting the "back" button (for example, from the ProductDetails page), even though the products themselves were still filtered.  Fixed it so that applied filters are visible even if they do not start at default.